### PR TITLE
fix infinite loop caused by error

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -29,7 +29,7 @@ type Errno int
 func (e Errno) Error() string {
 	s := C.GoString(C.cs_strerror(C.cs_err(e)))
 	if s == "" {
-		return fmt.Sprintf("Internal Error: No Error string for Errno %v", e)
+		return fmt.Sprintf("Internal Error: No Error string for Errno %d", e)
 	}
 	return s
 }


### PR DESCRIPTION
When there is an internal error, use `%d` to avoid infinite loop caused by `%v`.